### PR TITLE
Clean up stack layout

### DIFF
--- a/src/components/controls/RoomStackControl.tsx
+++ b/src/components/controls/RoomStackControl.tsx
@@ -1,30 +1,49 @@
-import React, { FunctionComponent } from 'react';
-import { useStackDimensions } from '../roomStack/RoomStack';
+import React, { CSSProperties, FunctionComponent } from 'react';
+import { translate } from '../geometry';
+import {
+  calcUnitsLength,
+  getAreaBoundingBox,
+  xUnits,
+  yUnits,
+} from '../roomStack/RoomStack';
 import { useWindowDimensions } from '../windowDimensions';
 
 interface RoomStackControlProps {}
 
 const RoomStackControl: FunctionComponent<RoomStackControlProps> = () => {
-  const { height } = useWindowDimensions();
   const {
-    topLeft: { x: stackX },
-    dimensions: { width: stackWidth },
-  } = useStackDimensions();
+    topLeft: areaTopLeft,
+    dimensions: { height: areaHeight },
+  } = getAreaBoundingBox(useWindowDimensions());
+  const { x, y } = translate(
+    areaTopLeft,
+    calcUnitsLength(areaHeight, yUnits.spacing),
+    calcUnitsLength(areaHeight, yUnits.spacing + yUnits.room + yUnits.spacing)
+  );
+  const spacing = calcUnitsLength(areaHeight, yUnits.spacing);
+  const buttonWidth = calcUnitsLength(areaHeight, xUnits.button);
+  const buttonHeight = calcUnitsLength(areaHeight, yUnits.button);
+  const buttonStyle: CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    width: buttonWidth,
+    height: buttonHeight,
+  };
 
   return (
     <div
       className="room-stack-control"
       style={{
         position: 'absolute',
-        top: height - 50,
-        left: stackX,
-        width: stackWidth,
-        display: 'flex',
-        justifyContent: 'space-around',
+        top: y,
+        left: x,
+        width: buttonWidth + spacing + buttonWidth,
       }}
     >
-      <button>Use</button>
-      <button>Next</button>
+      <button style={{ left: 0, ...buttonStyle }}>Use</button>
+      <button style={{ left: buttonWidth + spacing, ...buttonStyle }}>
+        Next
+      </button>
     </div>
   );
 };

--- a/src/components/geometry.ts
+++ b/src/components/geometry.ts
@@ -45,8 +45,3 @@ export const rotate: (p: Point, center: Point, rotation: number) => Point = (
     y: -x * sin - y * cos,
   });
 };
-
-export interface Dimensions {
-  width: number;
-  height: number;
-}

--- a/src/components/layout.ts
+++ b/src/components/layout.ts
@@ -1,0 +1,11 @@
+import { Point } from './geometry';
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}
+
+export interface BoundingBox {
+  topLeft: Point;
+  dimensions: Dimensions;
+}

--- a/src/components/roomStack/RoomStack.tsx
+++ b/src/components/roomStack/RoomStack.tsx
@@ -149,7 +149,7 @@ export const getAreaBoundingBox: (
 ) => BoundingBox = (windowDimensions) => {
   const { width: windowWidth, height: windowHeight } = windowDimensions;
 
-  const height = windowHeight / 3;
+  const height = Math.max(windowHeight / 3, 250);
   const width = calcUnitsLength(height, totalXUnits);
 
   return {

--- a/src/components/roomStack/RoomStack.tsx
+++ b/src/components/roomStack/RoomStack.tsx
@@ -8,10 +8,7 @@ import {
 import { Dimensions, Point, translate } from '../geometry';
 import { useWindowDimensions } from '../windowDimensions';
 
-const aspectRatio = 1;
-const maxWidth = 250;
-
-const yUnits = {
+export const yUnits = {
   spacing: 1,
   room: 8,
   button: 2,
@@ -24,9 +21,13 @@ const totalYUnits =
   yUnits.button +
   yUnits.spacing;
 
+export const xUnits = {
+  button: (yUnits.room - yUnits.spacing) / 2,
+};
+
 const totalXUnits = yUnits.spacing + yUnits.room + yUnits.spacing;
 
-const calcUnitsLength = (areaHeight: number, units: number) =>
+export const calcUnitsLength = (areaHeight: number, units: number) =>
   areaHeight * (units / totalYUnits);
 
 const pointsToArray: (points: Point[]) => number[] = (points) => {
@@ -219,23 +220,6 @@ const StackRoom: FunctionComponent<StackRoomProps> = ({
       <House roomBox={roomBox} nextRoom={nextRoom} />
     </Group>
   );
-};
-
-interface StackDimensions {
-  topLeft: Point;
-  dimensions: Dimensions;
-}
-
-export const useStackDimensions: () => StackDimensions = () => {
-  const windowDimensions = useWindowDimensions();
-  const width = Math.min(maxWidth, windowDimensions.width / 3);
-  const height = width * aspectRatio;
-  const topLeft = {
-    x: windowDimensions.width - width,
-    y: windowDimensions.height - height,
-  };
-
-  return { topLeft, dimensions: { width, height } };
 };
 
 const RoomStack: FunctionComponent<RoomStackState> = ({ nextRoom }) => {

--- a/src/components/roomStack/RoomStack.tsx
+++ b/src/components/roomStack/RoomStack.tsx
@@ -5,7 +5,8 @@ import {
   RoomStackState,
   StackRoom as StackRoomModel,
 } from '../../features/roomStack';
-import { Dimensions, Point, translate } from '../geometry';
+import { Point, translate } from '../geometry';
+import { BoundingBox, Dimensions } from '../layout';
 import { useWindowDimensions } from '../windowDimensions';
 
 export const yUnits = {
@@ -96,11 +97,6 @@ const drawFloor = (
     />
   );
 };
-
-interface BoundingBox {
-  topLeft: Point;
-  dimensions: Dimensions;
-}
 
 const getHouseBoundingBox: (roomBox: BoundingBox) => BoundingBox = (
   roomBox

--- a/src/components/roomStack/RoomStack.tsx
+++ b/src/components/roomStack/RoomStack.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Group, Line, Rect } from 'react-konva';
+import { Group, Line, Rect, Text } from 'react-konva';
 import {
   Floor,
   RoomStackState,
@@ -162,7 +162,7 @@ export const getAreaBoundingBox: (
 
 interface HouseProps {
   roomBox: BoundingBox;
-  nextRoom?: StackRoomModel;
+  nextRoom: StackRoomModel;
 }
 
 const House: FunctionComponent<HouseProps> = ({ roomBox, nextRoom }) => {
@@ -174,21 +174,15 @@ const House: FunctionComponent<HouseProps> = ({ roomBox, nextRoom }) => {
 
   return (
     <Group>
-      {nextRoom &&
-        [
-          Floor.ROOF,
-          Floor.UPPER,
-          Floor.GROUND,
-          Floor.BASEMENT,
-        ].map((floor, i) =>
-          drawFloor(
-            floor,
-            nextRoom.possibleFloors,
-            translate(topLeft, 0, i * floorHeight),
-            width,
-            floorHeight
-          )
-        )}
+      {[Floor.ROOF, Floor.UPPER, Floor.GROUND, Floor.BASEMENT].map((floor, i) =>
+        drawFloor(
+          floor,
+          nextRoom.possibleFloors,
+          translate(topLeft, 0, i * floorHeight),
+          width,
+          floorHeight
+        )
+      )}
 
       <Line
         points={getHousePoints(topLeft, width, floorHeight)}
@@ -210,11 +204,22 @@ const StackRoom: FunctionComponent<StackRoomProps> = ({
     dimensions: { width, height },
   } = roomBox;
 
-  return (
+  return nextRoom ? (
     <Group>
       <Rect x={x} y={y} width={width} height={height} fill="black" />
       <House roomBox={roomBox} nextRoom={nextRoom} />
     </Group>
+  ) : (
+    <Text
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      align="center"
+      verticalAlign="middle"
+      fontSize={16}
+      text="Empty"
+    />
   );
 };
 

--- a/src/components/roomStack/RoomStack.tsx
+++ b/src/components/roomStack/RoomStack.tsx
@@ -171,16 +171,9 @@ const House: FunctionComponent<HouseProps> = ({ roomBox, nextRoom }) => {
     dimensions: { width, height },
   } = getHouseBoundingBox(roomBox);
   const floorHeight = height / 4;
-  const outlineStyle = nextRoom ? { fill: 'black' } : { dash: [20, 10] };
 
   return (
     <Group>
-      <Line
-        points={getHousePoints(topLeft, width, floorHeight)}
-        stroke="gray"
-        closed={true}
-        {...outlineStyle}
-      />
       {nextRoom &&
         [
           Floor.ROOF,
@@ -196,6 +189,13 @@ const House: FunctionComponent<HouseProps> = ({ roomBox, nextRoom }) => {
             floorHeight
           )
         )}
+
+      <Line
+        points={getHousePoints(topLeft, width, floorHeight)}
+        closed={true}
+        stroke="gray"
+        strokeWidth={3}
+      />
     </Group>
   );
 };

--- a/src/components/roomStack/RoomStack.tsx
+++ b/src/components/roomStack/RoomStack.tsx
@@ -49,10 +49,29 @@ const getHousePoints: (
   return pointsToArray([peak, upperRight, lowerRight, lowerLeft, upperLeft]);
 };
 
-interface StackRoomProps {
-  nextRoom?: StackRoomModel;
-  areaBox: BoundingBox;
-}
+const getHouseBoundingBox: (roomBox: BoundingBox) => BoundingBox = (
+  roomBox
+) => {
+  const {
+    topLeft: roomTopLeft,
+    dimensions: { width: roomWidth, height: roomHeight },
+  } = roomBox;
+
+  const houseWidth = roomWidth * 0.8;
+  const houseHeight = roomHeight * 0.8;
+
+  return {
+    topLeft: translate(
+      roomTopLeft,
+      (roomWidth - houseWidth) / 2,
+      (roomHeight - houseHeight) / 2
+    ),
+    dimensions: {
+      width: houseWidth,
+      height: houseHeight,
+    },
+  };
+};
 
 const drawFloor = (
   floor: Floor,
@@ -98,68 +117,6 @@ const drawFloor = (
   );
 };
 
-const getHouseBoundingBox: (roomBox: BoundingBox) => BoundingBox = (
-  roomBox
-) => {
-  const {
-    topLeft: roomTopLeft,
-    dimensions: { width: roomWidth, height: roomHeight },
-  } = roomBox;
-
-  const houseWidth = roomWidth * 0.8;
-  const houseHeight = roomHeight * 0.8;
-
-  return {
-    topLeft: translate(
-      roomTopLeft,
-      (roomWidth - houseWidth) / 2,
-      (roomHeight - houseHeight) / 2
-    ),
-    dimensions: {
-      width: houseWidth,
-      height: houseHeight,
-    },
-  };
-};
-
-const getRoomBoundingBox: (areaBox: BoundingBox) => BoundingBox = (areaBox) => {
-  const {
-    topLeft: areaTopLeft,
-    dimensions: { height: areaHeight },
-  } = areaBox;
-
-  const roomSize = calcUnitsLength(areaHeight, yUnits.room);
-  const spacing = calcUnitsLength(areaHeight, yUnits.spacing);
-
-  return {
-    topLeft: translate(areaTopLeft, spacing, spacing),
-    dimensions: {
-      width: roomSize,
-      height: roomSize,
-    },
-  };
-};
-
-export const getAreaBoundingBox: (
-  windowDimensions: Dimensions
-) => BoundingBox = (windowDimensions) => {
-  const { width: windowWidth, height: windowHeight } = windowDimensions;
-
-  const height = Math.max(windowHeight / 3, 250);
-  const width = calcUnitsLength(height, totalXUnits);
-
-  return {
-    topLeft: {
-      x: windowWidth - width,
-      y: windowHeight - height,
-    },
-    dimensions: {
-      width,
-      height,
-    },
-  };
-};
-
 interface HouseProps {
   roomBox: BoundingBox;
   nextRoom: StackRoomModel;
@@ -194,6 +151,29 @@ const House: FunctionComponent<HouseProps> = ({ roomBox, nextRoom }) => {
   );
 };
 
+const getRoomBoundingBox: (areaBox: BoundingBox) => BoundingBox = (areaBox) => {
+  const {
+    topLeft: areaTopLeft,
+    dimensions: { height: areaHeight },
+  } = areaBox;
+
+  const roomSize = calcUnitsLength(areaHeight, yUnits.room);
+  const spacing = calcUnitsLength(areaHeight, yUnits.spacing);
+
+  return {
+    topLeft: translate(areaTopLeft, spacing, spacing),
+    dimensions: {
+      width: roomSize,
+      height: roomSize,
+    },
+  };
+};
+
+interface StackRoomProps {
+  nextRoom?: StackRoomModel;
+  areaBox: BoundingBox;
+}
+
 const StackRoom: FunctionComponent<StackRoomProps> = ({
   areaBox,
   nextRoom,
@@ -221,6 +201,26 @@ const StackRoom: FunctionComponent<StackRoomProps> = ({
       text="Empty"
     />
   );
+};
+
+export const getAreaBoundingBox: (
+  windowDimensions: Dimensions
+) => BoundingBox = (windowDimensions) => {
+  const { width: windowWidth, height: windowHeight } = windowDimensions;
+
+  const height = Math.max(windowHeight / 3, 250);
+  const width = calcUnitsLength(height, totalXUnits);
+
+  return {
+    topLeft: {
+      x: windowWidth - width,
+      y: windowHeight - height,
+    },
+    dimensions: {
+      width,
+      height,
+    },
+  };
 };
 
 const RoomStack: FunctionComponent<RoomStackState> = ({ nextRoom }) => {

--- a/src/components/windowDimensions.tsx
+++ b/src/components/windowDimensions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Dimensions } from './geometry';
+import { Dimensions } from './layout';
 
 const getWindowDimensions: () => Dimensions = () => {
   const { innerWidth: width, innerHeight: height } = window;


### PR DESCRIPTION
My plan is to have the room stack card flip over in-place when you select it so you can see the doors and find a place in the house to put it. This meant drawing the card around the floors depiction as it exists today.

My layout code for the room stack area was pretty janky so I opted to clean it up a bit. It's better, but it still feels a bit hard-coded.

I'd love to come up with a more general solution for laying out an area like this. My head kept coming back to the idea of a constraint layout like is available in Android development, but that would allow me to mix DOM and canvas elements so all that layout code can be colocated. I'll come back to this idea.