### PR TITLE
Implement player movement

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -171,3 +171,17 @@ export const getRooms: () => Promise<Room[]> = async () => {
     };
   });
 };
+
+export const movePlayer: (
+  color: PlayerColor,
+  loc: GridLoc
+) => Promise<Room[]> = async (color, loc) => {
+  const player = players.find((player) => player.color === color);
+
+  if (!player) {
+    throw new Error("can't move player that isn't in the game");
+  }
+
+  player.loc = loc;
+  return getRooms();
+};

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,8 +1,9 @@
-import { equal, GridLoc } from '../components/board/grid';
+import { GridLoc } from '../components/board/grid';
 import { Direction } from '../components/room/Room';
 import {
   FlippedRoom,
   Floor,
+  Player,
   PlayerColor,
   Room,
   StackRoom,
@@ -95,12 +96,7 @@ export const rotateFlipped = async () => {
   return flippedRoom;
 };
 
-interface PlayerModel {
-  loc: GridLoc;
-  color: PlayerColor;
-}
-
-let players: PlayerModel[] = [
+let players: Player[] = [
   { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.YELLOW },
   { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.RED },
   { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.GREEN },
@@ -109,9 +105,7 @@ let players: PlayerModel[] = [
   { loc: { gridX: 1, gridY: 2 }, color: PlayerColor.BLUE },
 ];
 
-type RoomWithoutPlayers = Omit<Room, 'players'>;
-
-let rooms: RoomWithoutPlayers[] = [
+let rooms: Room[] = [
   {
     name: 'Bloody Room',
     loc: { gridX: 2, gridY: 2 },
@@ -164,18 +158,17 @@ export const placeRoom: (loc: GridLoc) => Promise<PlaceRoomResponse> = async (
 };
 
 export const getRooms: () => Promise<Room[]> = async () => {
-  return rooms.map((room) => {
-    return {
-      ...room,
-      players: players.filter((player) => equal(player.loc, room.loc)),
-    };
-  });
+  return rooms;
+};
+
+export const getPlayers: () => Promise<Player[]> = async () => {
+  return players;
 };
 
 export const movePlayer: (
   color: PlayerColor,
   loc: GridLoc
-) => Promise<Room[]> = async (color, loc) => {
+) => Promise<Player[]> = async (color, loc) => {
   const player = players.find((player) => player.color === color);
 
   if (!player) {
@@ -185,5 +178,5 @@ export const movePlayer: (
   players = players
     .filter((player) => player.color !== color)
     .concat({ loc, color });
-  return getRooms();
+  return getPlayers();
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -182,6 +182,8 @@ export const movePlayer: (
     throw new Error("can't move player that isn't in the game");
   }
 
-  player.loc = loc;
+  players = players
+    .filter((player) => player.color !== color)
+    .concat({ loc, color });
   return getRooms();
 };

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -143,7 +143,9 @@ export interface PlaceRoomResponse {
   rooms: Room[];
   nextRoom?: StackRoom;
 }
-export const placeRoom = async (loc: GridLoc) => {
+export const placeRoom: (loc: GridLoc) => Promise<PlaceRoomResponse> = async (
+  loc
+) => {
   if (!flippedRoom) {
     throw new Error("can't place room since there isn't one flipped");
   }
@@ -156,9 +158,9 @@ export const placeRoom = async (loc: GridLoc) => {
   });
 
   return {
-    rooms,
+    rooms: await getRooms(),
     nextRoom: await getStackRoom(),
-  } as PlaceRoomResponse;
+  };
 };
 
 export const getRooms: () => Promise<Room[]> = async () => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,4 +1,4 @@
-import { GridLoc } from '../components/board/grid';
+import { equal, GridLoc } from '../components/board/grid';
 import { Direction } from '../components/room/Room';
 import {
   FlippedRoom,
@@ -159,10 +159,6 @@ export const placeRoom = async (loc: GridLoc) => {
     rooms,
     nextRoom: await getStackRoom(),
   } as PlaceRoomResponse;
-};
-
-const equal: (l1: GridLoc, l2: GridLoc) => boolean = (l1, l2) => {
-  return l1.gridX === l2.gridX && l1.gridY === l2.gridY;
 };
 
 export const getRooms: () => Promise<Room[]> = async () => {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -95,7 +95,23 @@ export const rotateFlipped = async () => {
   return flippedRoom;
 };
 
-let rooms: Room[] = [
+interface PlayerModel {
+  loc: GridLoc;
+  color: PlayerColor;
+}
+
+let players: PlayerModel[] = [
+  { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.YELLOW },
+  { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.RED },
+  { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.GREEN },
+  { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.WHITE },
+  { loc: { gridX: 2, gridY: 1 }, color: PlayerColor.PURPLE },
+  { loc: { gridX: 1, gridY: 2 }, color: PlayerColor.BLUE },
+];
+
+type RoomWithoutPlayers = Omit<Room, 'players'>;
+
+let rooms: RoomWithoutPlayers[] = [
   {
     name: 'Bloody Room',
     loc: { gridX: 2, gridY: 2 },
@@ -105,31 +121,21 @@ let rooms: Room[] = [
       Direction.NORTH,
       Direction.WEST,
     ],
-    players: [],
   },
   {
     name: 'Statuary Corridor',
     loc: { gridX: 1, gridY: 2 },
     doorDirections: [Direction.EAST, Direction.SOUTH],
-    players: [{ color: PlayerColor.BLUE }],
   },
   {
     name: 'Master Bedroom',
     loc: { gridX: 2, gridY: 3 },
     doorDirections: [Direction.NORTH, Direction.SOUTH],
-    players: [],
   },
   {
     name: 'Crypt',
     loc: { gridX: 2, gridY: 1 },
     doorDirections: [Direction.SOUTH],
-    players: [
-      { color: PlayerColor.YELLOW },
-      { color: PlayerColor.RED },
-      { color: PlayerColor.GREEN },
-      { color: PlayerColor.WHITE },
-      { color: PlayerColor.PURPLE },
-    ],
   },
 ];
 
@@ -147,7 +153,6 @@ export const placeRoom = async (loc: GridLoc) => {
     name,
     doorDirections,
     loc,
-    players: [],
   });
 
   return {
@@ -156,6 +161,15 @@ export const placeRoom = async (loc: GridLoc) => {
   } as PlaceRoomResponse;
 };
 
-export const getRooms = async () => {
-  return rooms;
+const equal: (l1: GridLoc, l2: GridLoc) => boolean = (l1, l2) => {
+  return l1.gridX === l2.gridX && l1.gridY === l2.gridY;
+};
+
+export const getRooms: () => Promise<Room[]> = async () => {
+  return rooms.map((room) => {
+    return {
+      ...room,
+      players: players.filter((player) => equal(player.loc, room.loc)),
+    };
+  });
 };

--- a/src/board.ts
+++ b/src/board.ts
@@ -3,18 +3,18 @@ import { Direction } from './components/room/Room';
 import { Room as RoomModel } from './features/models';
 import { index } from './utils';
 
-type BoardMap = Record<number, Record<number, RoomModel>>;
+type BoardMap = Map<number, Map<number, RoomModel>>;
 
 export const buildBoardMap: (rooms: RoomModel[]) => BoardMap = (rooms) => {
-  const map: BoardMap = {};
+  const map: BoardMap = new Map();
 
   for (const room of rooms) {
     const { gridX: x, gridY: y } = room.loc;
-    if (!(x in map)) {
-      map[x] = {};
+    if (!map.get(x)) {
+      map.set(x, new Map());
     }
 
-    map[x][y] = room;
+    map.get(x)!!.set(y, room);
   }
 
   return map;
@@ -56,12 +56,12 @@ const getNeighbors: (room: RoomModel) => Neighbor[] = (room) => {
 
 const isOpen: (loc: GridLoc, map: BoardMap) => boolean = (loc, map) => {
   const { gridX: x, gridY: y } = loc;
-  return !(map[x] && map[x][y]);
+  return !map.get(x)?.get(y);
 };
 
 export const findOpenNeighbors: (map: BoardMap) => Neighbor[] = (map) => {
-  const openNeighbors = Object.values(map)
-    .flatMap(Object.values)
+  const openNeighbors = Array.from(map.values())
+    .flatMap((column) => Array.from(column.values()))
     .flatMap(getNeighbors)
     .filter(({ loc }) => isOpen(loc, map));
 

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,30 +1,22 @@
 import { GridLoc } from './components/board/grid';
 import { Direction } from './components/room/Room';
 import { Room as RoomModel } from './features/models';
+import { buildCartMap, CartMap, getXY } from './map';
 import { index } from './utils';
 
-type BoardMap = Map<number, Map<number, RoomModel>>;
+type BoardMap = CartMap<RoomModel>;
 
 export const get: (map: BoardMap, loc: GridLoc) => RoomModel | undefined = (
   map,
   { gridX, gridY }
 ) => {
-  return map.get(gridX)?.get(gridY);
+  return getXY(map, gridX, gridY);
 };
 
 export const buildBoardMap: (rooms: RoomModel[]) => BoardMap = (rooms) => {
-  const map: BoardMap = new Map();
-
-  for (const room of rooms) {
-    const { gridX: x, gridY: y } = room.loc;
-    if (!map.get(x)) {
-      map.set(x, new Map());
-    }
-
-    map.get(x)!!.set(y, room);
-  }
-
-  return map;
+  return buildCartMap(rooms, ({ loc: { gridX: x, gridY: y } }) => {
+    return { x, y };
+  });
 };
 
 const getDelta: (dir: Direction) => [number, number] = (dir) => {
@@ -63,7 +55,7 @@ const getNeighbors: (room: RoomModel) => Neighbor[] = (room) => {
 
 const isOpen: (loc: GridLoc, map: BoardMap) => boolean = (loc, map) => {
   const { gridX: x, gridY: y } = loc;
-  return !map.get(x)?.get(y);
+  return !getXY(map, x, y);
 };
 
 export const findOpenNeighbors: (map: BoardMap) => Neighbor[] = (map) => {

--- a/src/board.ts
+++ b/src/board.ts
@@ -5,6 +5,13 @@ import { index } from './utils';
 
 type BoardMap = Map<number, Map<number, RoomModel>>;
 
+export const get: (map: BoardMap, loc: GridLoc) => RoomModel | undefined = (
+  map,
+  { gridX, gridY }
+) => {
+  return map.get(gridX)?.get(gridY);
+};
+
 export const buildBoardMap: (rooms: RoomModel[]) => BoardMap = (rooms) => {
   const map: BoardMap = new Map();
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,6 +8,7 @@ import RoomStack from './roomStack/RoomStack';
 import { useWindowDimensions } from './windowDimensions';
 import { moveBoard } from '../features/board';
 import { RootState } from '../rootReducer';
+import Players from './players/Players';
 
 const App = () => {
   const { width, height } = useWindowDimensions();
@@ -34,6 +35,7 @@ const App = () => {
               >
                 <Rect x={x} y={y} width={width} height={height} />
                 <Board />
+                <Players />
               </Layer>
               <Layer>
                 <RoomStack />

--- a/src/components/board/BoardRoom.tsx
+++ b/src/components/board/BoardRoom.tsx
@@ -3,14 +3,12 @@ import { Group } from 'react-konva';
 import Room from '../room/Room';
 import RoomName from '../room/RoomName';
 import { useGridSize, useGridTopLeft } from './grid';
-import Players from './Players';
 import { Room as RoomModel } from '../../features/models';
 
 const BoardRoom: FunctionComponent<RoomModel> = ({
   name,
   loc,
   doorDirections,
-  players,
 }) => {
   const topLeft = useGridTopLeft(loc);
   const gridSize = useGridSize();
@@ -25,7 +23,6 @@ const BoardRoom: FunctionComponent<RoomModel> = ({
         box={{ topLeft, dimensions: { width: gridSize, height: gridSize / 2 } }}
         name={name}
       />
-      <Players players={players} roomLoc={loc} />
     </Group>
   );
 };

--- a/src/components/board/Players.tsx
+++ b/src/components/board/Players.tsx
@@ -51,9 +51,8 @@ const Player: FunctionComponent<PlayerProps> = ({ center, color }) => {
       draggable
       onDragEnd={(e) => {
         e.cancelBubble = true; // avoid dragging the board
-        const pointDroppedOn = { x: e.target.x(), y: e.target.y() };
         const gridDroppedOn = windowToGridLoc(
-          pointDroppedOn,
+          e.target.position(),
           gridSize,
           boardTopLeft
         );

--- a/src/components/board/Players.tsx
+++ b/src/components/board/Players.tsx
@@ -2,13 +2,7 @@ import React, { FunctionComponent, useState } from 'react';
 import { Circle, Group } from 'react-konva';
 import { partition } from '../../utils';
 import { add, Point, translate } from '../geometry';
-import {
-  centerDroppedOnGrid,
-  droppedOnGrid,
-  GridLoc,
-  useGridSize,
-  useGridTopLeft,
-} from './grid';
+import { GridLoc, useGridSize, useGridTopLeft, windowToGridLoc } from './grid';
 import { Player as PlayerModel } from '../../features/models';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../rootReducer';
@@ -57,8 +51,13 @@ const Player: FunctionComponent<PlayerProps> = ({ center, color }) => {
       draggable
       onDragEnd={(e) => {
         e.cancelBubble = true; // avoid dragging the board
-        const loc = centerDroppedOnGrid(e, center, gridSize, boardTopLeft);
-        dispatch(playerDropped(color, loc));
+        const pointDroppedOn = { x: e.target.x(), y: e.target.y() };
+        const gridDroppedOn = windowToGridLoc(
+          pointDroppedOn,
+          gridSize,
+          boardTopLeft
+        );
+        dispatch(playerDropped(color, gridDroppedOn));
         setCenter({ x: e.target.x(), y: e.target.y() });
         setCenter(center);
       }}

--- a/src/components/board/Players.tsx
+++ b/src/components/board/Players.tsx
@@ -1,9 +1,18 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import { Circle, Group } from 'react-konva';
 import { partition } from '../../utils';
 import { add, Point, translate } from '../geometry';
-import { GridLoc, useGridSize, useGridTopLeft } from './grid';
+import {
+  centerDroppedOnGrid,
+  droppedOnGrid,
+  GridLoc,
+  useGridSize,
+  useGridTopLeft,
+} from './grid';
 import { Player as PlayerModel } from '../../features/models';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../rootReducer';
+import { playerDropped } from '../../features/board';
 
 const usePlayerRadius: () => number = () => {
   return useGridSize() / 15;
@@ -32,10 +41,12 @@ export interface PlayerProps extends PlayerModel {
   center: Point;
 }
 
-const Player: FunctionComponent<PlayerProps> = ({
-  center: { x, y },
-  color,
-}) => {
+const Player: FunctionComponent<PlayerProps> = ({ center, color }) => {
+  const [{ x, y }, setCenter] = useState(center);
+  const dispatch = useDispatch();
+  const gridSize = useGridSize();
+  const boardTopLeft = useSelector((state: RootState) => state.board.topLeft);
+
   return (
     <Circle
       x={x}
@@ -43,6 +54,13 @@ const Player: FunctionComponent<PlayerProps> = ({
       radius={usePlayerRadius()}
       fill={color}
       stroke="white"
+      draggable
+      onDragEnd={(e) => {
+        const loc = centerDroppedOnGrid(e, center, gridSize, boardTopLeft);
+        dispatch(playerDropped(color, loc));
+        setCenter({ x: e.target.x(), y: e.target.y() });
+        setCenter(center);
+      }}
     />
   );
 };

--- a/src/components/board/Players.tsx
+++ b/src/components/board/Players.tsx
@@ -56,6 +56,7 @@ const Player: FunctionComponent<PlayerProps> = ({ center, color }) => {
       stroke="white"
       draggable
       onDragEnd={(e) => {
+        e.cancelBubble = true; // avoid dragging the board
         const loc = centerDroppedOnGrid(e, center, gridSize, boardTopLeft);
         dispatch(playerDropped(color, loc));
         setCenter({ x: e.target.x(), y: e.target.y() });

--- a/src/components/board/grid.ts
+++ b/src/components/board/grid.ts
@@ -42,35 +42,3 @@ export const windowToGridLoc: (
     gridY: Math.floor((y + boardY) / gridSize),
   };
 };
-
-export const centerDroppedOnGrid: (
-  e: KonvaEventObject<DragEvent>,
-  originalCenter: Point,
-  gridSize: number,
-  boardTopLeft: Point
-) => GridLoc = (e, originalCenter, gridSize, boardTopLeft) => {
-  const center = translate(originalCenter, e.target.x(), e.target.y());
-  return windowToGridLoc(center, gridSize, boardTopLeft);
-};
-
-export const droppedOnGrid: (
-  e: KonvaEventObject<DragEvent>,
-  originalTargetBox: BoundingBox,
-  gridSize: number,
-  boardTopLeft: Point
-) => GridLoc = (
-  e,
-  {
-    topLeft: originalTargetTopLeft,
-    dimensions: { width: targetWidth, height: targetHeight },
-  },
-  gridSize,
-  boardTopLeft
-) => {
-  const originalCenter = translate(
-    originalTargetTopLeft,
-    targetWidth / 2,
-    targetHeight / 2
-  );
-  return centerDroppedOnGrid(e, originalCenter, gridSize, boardTopLeft);
-};

--- a/src/components/board/grid.ts
+++ b/src/components/board/grid.ts
@@ -1,8 +1,6 @@
-import { KonvaEventObject } from 'konva/types/Node';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../rootReducer';
-import { Point, translate } from '../geometry';
-import { BoundingBox } from '../layout';
+import { Point } from '../geometry';
 
 // (0, 0) is top-left square on first render
 export interface GridLoc {

--- a/src/components/board/grid.ts
+++ b/src/components/board/grid.ts
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../rootReducer';
-import { Point } from '../geometry';
+import { Point, translate } from '../geometry';
 
 // (0, 0) is top-left square on first render
 export interface GridLoc {
@@ -30,13 +30,20 @@ export const useGridCenter: (loc: GridLoc) => Point = ({ gridX, gridY }) => {
   return { x: (gridX + 0.5) * gridSize, y: (gridY + 0.5) * gridSize };
 };
 
+export const pointToGridLoc: (p: Point, gridSize: number) => GridLoc = (
+  { x, y },
+  gridSize
+) => {
+  return {
+    gridX: Math.floor(x / gridSize),
+    gridY: Math.floor(y / gridSize),
+  };
+};
+
 export const windowToGridLoc: (
   windowPoint: Point,
   gridSize: number,
   boardTopLeft: Point
-) => GridLoc = ({ x, y }, gridSize, { x: boardX, y: boardY }) => {
-  return {
-    gridX: Math.floor((x + boardX) / gridSize),
-    gridY: Math.floor((y + boardY) / gridSize),
-  };
+) => GridLoc = (windowPoint, gridSize, { x: boardX, y: boardY }) => {
+  return pointToGridLoc(translate(windowPoint, boardX, boardY), gridSize);
 };

--- a/src/components/board/grid.ts
+++ b/src/components/board/grid.ts
@@ -43,6 +43,16 @@ export const windowToGridLoc: (
   };
 };
 
+export const centerDroppedOnGrid: (
+  e: KonvaEventObject<DragEvent>,
+  originalCenter: Point,
+  gridSize: number,
+  boardTopLeft: Point
+) => GridLoc = (e, originalCenter, gridSize, boardTopLeft) => {
+  const center = translate(originalCenter, e.target.x(), e.target.y());
+  return windowToGridLoc(center, gridSize, boardTopLeft);
+};
+
 export const droppedOnGrid: (
   e: KonvaEventObject<DragEvent>,
   originalTargetBox: BoundingBox,
@@ -57,11 +67,10 @@ export const droppedOnGrid: (
   gridSize,
   boardTopLeft
 ) => {
-  const targetTopLeft = translate(
+  const originalCenter = translate(
     originalTargetTopLeft,
-    e.target.x(),
-    e.target.y()
+    targetWidth / 2,
+    targetHeight / 2
   );
-  const center = translate(targetTopLeft, targetWidth / 2, targetHeight / 2);
-  return windowToGridLoc(center, gridSize, boardTopLeft);
+  return centerDroppedOnGrid(e, originalCenter, gridSize, boardTopLeft);
 };

--- a/src/components/board/grid.ts
+++ b/src/components/board/grid.ts
@@ -10,6 +10,10 @@ export interface GridLoc {
   gridY: number;
 }
 
+export const equal: (l1: GridLoc, l2: GridLoc) => boolean = (l1, l2) => {
+  return l1.gridX === l2.gridX && l1.gridY === l2.gridY;
+};
+
 export const toString: (loc: GridLoc) => string = ({ gridX, gridY }) => {
   return `(${gridX}, ${gridY})`;
 };

--- a/src/components/players/Players.tsx
+++ b/src/components/players/Players.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from 'react';
+import { Group } from 'react-konva';
+import { useSelector } from 'react-redux';
+import { getPlayerMap } from '../../features/selectors';
+import { mapCartMap } from '../../map';
+import { toString } from '../board/grid';
+import RoomPlayers from './RoomPlayers';
+
+const Players: FunctionComponent<{}> = () => {
+  const playerMap = useSelector(getPlayerMap);
+  if (!playerMap) {
+    return null;
+  }
+
+  return (
+    <Group>
+      {mapCartMap(playerMap, ({ x, y }, players) => {
+        const loc = { gridX: x, gridY: y };
+        return (
+          <RoomPlayers key={toString(loc)} players={players} roomLoc={loc} />
+        );
+      })}
+    </Group>
+  );
+};
+
+export default Players;

--- a/src/components/players/RoomPlayers.tsx
+++ b/src/components/players/RoomPlayers.tsx
@@ -4,13 +4,12 @@ import { partition } from '../../utils';
 import { add, Point, translate } from '../geometry';
 import {
   GridLoc,
+  pointToGridLoc,
   useGridSize,
   useGridTopLeft,
-  windowToGridLoc,
 } from '../board/grid';
 import { Player as PlayerModel } from '../../features/models';
-import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '../../rootReducer';
+import { useDispatch } from 'react-redux';
 import { playerDropped } from '../../features/players';
 
 const usePlayerRadius: () => number = () => {
@@ -44,7 +43,6 @@ const Player: FunctionComponent<PlayerProps> = ({ center, color }) => {
   const [{ x, y }, setCenter] = useState(center);
   const dispatch = useDispatch();
   const gridSize = useGridSize();
-  const boardTopLeft = useSelector((state: RootState) => state.board.topLeft);
 
   return (
     <Circle
@@ -56,12 +54,11 @@ const Player: FunctionComponent<PlayerProps> = ({ center, color }) => {
       draggable
       onDragEnd={(e) => {
         e.cancelBubble = true; // avoid dragging the board
-        const gridDroppedOn = windowToGridLoc(
-          e.target.position(),
-          gridSize,
-          boardTopLeft
+
+        dispatch(
+          playerDropped(color, pointToGridLoc(e.target.position(), gridSize))
         );
-        dispatch(playerDropped(color, gridDroppedOn));
+
         setCenter({ x: e.target.x(), y: e.target.y() });
         setCenter(center);
       }}

--- a/src/components/players/RoomPlayers.tsx
+++ b/src/components/players/RoomPlayers.tsx
@@ -2,11 +2,16 @@ import React, { FunctionComponent, useState } from 'react';
 import { Circle, Group } from 'react-konva';
 import { partition } from '../../utils';
 import { add, Point, translate } from '../geometry';
-import { GridLoc, useGridSize, useGridTopLeft, windowToGridLoc } from './grid';
+import {
+  GridLoc,
+  useGridSize,
+  useGridTopLeft,
+  windowToGridLoc,
+} from '../board/grid';
 import { Player as PlayerModel } from '../../features/models';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../rootReducer';
-import { playerDropped } from '../../features/board';
+import { playerDropped } from '../../features/players';
 
 const usePlayerRadius: () => number = () => {
   return useGridSize() / 15;
@@ -104,12 +109,15 @@ const PlayersRow: FunctionComponent<PlayersRowProps> = ({
   );
 };
 
-export interface PlayersProps {
+export interface RoomPlayersProps {
   players: PlayerModel[];
   roomLoc: GridLoc;
 }
 
-const Players: FunctionComponent<PlayersProps> = ({ players, roomLoc }) => {
+const RoomPlayers: FunctionComponent<RoomPlayersProps> = ({
+  players,
+  roomLoc,
+}) => {
   const { width, height, topLeft } = usePlayersDimensions();
 
   const byRow = partition(players, 3);
@@ -131,4 +139,4 @@ const Players: FunctionComponent<PlayersProps> = ({ players, roomLoc }) => {
   );
 };
 
-export default Players;
+export default RoomPlayers;

--- a/src/components/players/RoomPlayers.tsx
+++ b/src/components/players/RoomPlayers.tsx
@@ -128,7 +128,7 @@ const RoomPlayers: FunctionComponent<RoomPlayersProps> = ({
     <Group>
       {byRow.map((row, i) => (
         <PlayersRow
-          key={i}
+          key={Math.random()}
           players={row}
           topLeft={translate(add(roomTopLeft, topLeft), 0, i * rowHeight)}
           width={width}

--- a/src/components/roomStack/FlippedStackRoom.tsx
+++ b/src/components/roomStack/FlippedStackRoom.tsx
@@ -35,10 +35,11 @@ const FlippedStackRoom: FunctionComponent<FlippedStackRoomProps> = ({
     <Group
       draggable
       onDragEnd={(e) => {
+        const { x, y } = e.target.position();
         const pointDroppedOn = translate(
           roomTopLeft,
-          e.target.x() + roomWidth / 2,
-          e.target.y() + roomHeight / 2
+          x + roomWidth / 2,
+          y + roomHeight / 2
         );
         const gridDroppedOn = windowToGridLoc(
           pointDroppedOn,
@@ -46,7 +47,7 @@ const FlippedStackRoom: FunctionComponent<FlippedStackRoomProps> = ({
           boardTopLeft
         );
         dispatch(flippedRoomDropped(gridDroppedOn));
-        setGroupTopLeft({ x: e.target.x(), y: e.target.y() });
+        setGroupTopLeft({ x, y });
         setGroupTopLeft({ x: 0, y: 0 });
       }}
       x={groupTopLeft.x}

--- a/src/components/roomStack/FlippedStackRoom.tsx
+++ b/src/components/roomStack/FlippedStackRoom.tsx
@@ -3,8 +3,8 @@ import { Group } from 'react-konva';
 import { useDispatch, useSelector } from 'react-redux';
 import { flippedRoomDropped } from '../../features/board';
 import { RootState } from '../../rootReducer';
-import { droppedOnGrid, useGridSize } from '../board/grid';
-import { Point } from '../geometry';
+import { useGridSize, windowToGridLoc } from '../board/grid';
+import { Point, translate } from '../geometry';
 import { BoundingBox } from '../layout';
 import Room, { Direction } from '../room/Room';
 import RoomName from '../room/RoomName';
@@ -22,6 +22,10 @@ const FlippedStackRoom: FunctionComponent<FlippedStackRoomProps> = ({
   doorDirections,
 }) => {
   const roomBox = getRoomBoundingBox(areaBox);
+  const {
+    topLeft: roomTopLeft,
+    dimensions: { width: roomWidth, height: roomHeight },
+  } = roomBox;
   const dispatch = useDispatch();
   const gridSize = useGridSize();
   const boardTopLeft = useSelector((state: RootState) => state.board.topLeft);
@@ -31,8 +35,17 @@ const FlippedStackRoom: FunctionComponent<FlippedStackRoomProps> = ({
     <Group
       draggable
       onDragEnd={(e) => {
-        const droppedOn = droppedOnGrid(e, roomBox, gridSize, boardTopLeft);
-        dispatch(flippedRoomDropped(droppedOn));
+        const pointDroppedOn = translate(
+          roomTopLeft,
+          e.target.x() + roomWidth / 2,
+          e.target.y() + roomHeight / 2
+        );
+        const gridDroppedOn = windowToGridLoc(
+          pointDroppedOn,
+          gridSize,
+          boardTopLeft
+        );
+        dispatch(flippedRoomDropped(gridDroppedOn));
         setGroupTopLeft({ x: e.target.x(), y: e.target.y() });
         setGroupTopLeft({ x: 0, y: 0 });
       }}

--- a/src/features/board.ts
+++ b/src/features/board.ts
@@ -10,10 +10,9 @@ import { Direction } from '../components/room/Room';
 import { RootState } from '../rootReducer';
 import * as api from '../api/api';
 import { PlaceRoomResponse } from '../api/api';
-import { PlayerColor, Room } from './models';
+import { Room } from './models';
 import { Point } from '../components/geometry';
-import { getBoardMap, getOpenNeighbors } from './selectors';
-import { get } from '../board';
+import { getOpenNeighbors } from './selectors';
 
 export const getRooms = createAsyncThunk('board/getStatus', api.getRooms);
 
@@ -82,31 +81,6 @@ export const flippedRoomDropped: (
   dispatch(openSpotClicked(relevantNeighbor.loc, relevantNeighbor.from));
 };
 
-interface MovePlayerPayload {
-  color: PlayerColor;
-  loc: GridLoc;
-}
-
-export const movePlayer = createAsyncThunk(
-  'board/movePlayerStatus',
-  ({ color, loc }: MovePlayerPayload) => api.movePlayer(color, loc)
-);
-
-export const playerDropped: (
-  color: PlayerColor,
-  loc: GridLoc
-) => ThunkAction<void, RootState, unknown, Action<string>> = (color, loc) => (
-  dispatch,
-  getState
-) => {
-  const map = getBoardMap(getState())!!;
-  if (!get(map, loc)) {
-    return;
-  }
-
-  dispatch(movePlayer({ color, loc }));
-};
-
 const initialState: BoardState = {
   topLeft: { x: 0, y: 0 },
 };
@@ -125,9 +99,6 @@ const boardSlice = createSlice({
         state.rooms = rooms;
       })
       .addCase(placeRoom.fulfilled, (state, { payload: { rooms } }) => {
-        state.rooms = rooms;
-      })
-      .addCase(movePlayer.fulfilled, (state, { payload: rooms }) => {
         state.rooms = rooms;
       });
   },

--- a/src/features/board.ts
+++ b/src/features/board.ts
@@ -5,7 +5,7 @@ import {
   PayloadAction,
   ThunkAction,
 } from '@reduxjs/toolkit';
-import { GridLoc } from '../components/board/grid';
+import { equal, GridLoc } from '../components/board/grid';
 import { Direction } from '../components/room/Room';
 import { RootState } from '../rootReducer';
 import * as api from '../api/api';
@@ -70,9 +70,8 @@ export const flippedRoomDropped: (
   getState
 ) => {
   const openNeighbors = getOpenNeighbors(getState());
-  const relevantNeighbor = openNeighbors?.find(
-    (neighbor) =>
-      neighbor.loc.gridX === loc.gridX && neighbor.loc.gridY === loc.gridY
+  const relevantNeighbor = openNeighbors?.find((neighbor) =>
+    equal(neighbor.loc, loc)
   );
 
   if (!relevantNeighbor) {

--- a/src/features/board.ts
+++ b/src/features/board.ts
@@ -10,9 +10,10 @@ import { Direction } from '../components/room/Room';
 import { RootState } from '../rootReducer';
 import * as api from '../api/api';
 import { PlaceRoomResponse } from '../api/api';
-import { Room } from './models';
+import { PlayerColor, Room } from './models';
 import { Point } from '../components/geometry';
-import { getOpenNeighbors } from './selectors';
+import { getBoardMap, getOpenNeighbors } from './selectors';
+import { get } from '../board';
 
 export const getRooms = createAsyncThunk('board/getStatus', api.getRooms);
 
@@ -81,6 +82,31 @@ export const flippedRoomDropped: (
   dispatch(openSpotClicked(relevantNeighbor.loc, relevantNeighbor.from));
 };
 
+interface MovePlayerPayload {
+  color: PlayerColor;
+  loc: GridLoc;
+}
+
+export const movePlayer = createAsyncThunk(
+  'board/movePlayerStatus',
+  ({ color, loc }: MovePlayerPayload) => api.movePlayer(color, loc)
+);
+
+export const playerDropped: (
+  color: PlayerColor,
+  loc: GridLoc
+) => ThunkAction<void, RootState, unknown, Action<string>> = (color, loc) => (
+  dispatch,
+  getState
+) => {
+  const map = getBoardMap(getState())!!;
+  if (!get(map, loc)) {
+    return;
+  }
+
+  dispatch(movePlayer({ color, loc }));
+};
+
 const initialState: BoardState = {
   topLeft: { x: 0, y: 0 },
 };
@@ -99,6 +125,9 @@ const boardSlice = createSlice({
         state.rooms = rooms;
       })
       .addCase(placeRoom.fulfilled, (state, { payload: { rooms } }) => {
+        state.rooms = rooms;
+      })
+      .addCase(movePlayer.fulfilled, (state, { payload: rooms }) => {
         state.rooms = rooms;
       });
   },

--- a/src/features/models.ts
+++ b/src/features/models.ts
@@ -12,13 +12,13 @@ export enum PlayerColor {
 
 export interface Player {
   color: PlayerColor;
+  loc: GridLoc;
 }
 
 export interface Room {
   name: string;
   loc: GridLoc;
   doorDirections: Direction[];
-  players: Player[];
 }
 
 export enum Floor {

--- a/src/features/players.ts
+++ b/src/features/players.ts
@@ -1,5 +1,42 @@
-import { createSlice } from '@reduxjs/toolkit';
-import { Player } from './models';
+import {
+  Action,
+  createAsyncThunk,
+  createSlice,
+  ThunkAction,
+} from '@reduxjs/toolkit';
+import { Player, PlayerColor } from './models';
+import * as api from '../api/api';
+import { GridLoc } from '../components/board/grid';
+import { RootState } from '../rootReducer';
+import { getBoardMap } from './selectors';
+import { get } from '../board';
+
+export const getPlayers = createAsyncThunk('players/getStatus', api.getPlayers);
+
+interface MovePlayerPayload {
+  color: PlayerColor;
+  loc: GridLoc;
+}
+
+export const movePlayer = createAsyncThunk(
+  'board/movePlayerStatus',
+  ({ color, loc }: MovePlayerPayload) => api.movePlayer(color, loc)
+);
+
+export const playerDropped: (
+  color: PlayerColor,
+  loc: GridLoc
+) => ThunkAction<void, RootState, unknown, Action<string>> = (color, loc) => (
+  dispatch,
+  getState
+) => {
+  const map = getBoardMap(getState())!!;
+  if (!get(map, loc)) {
+    return;
+  }
+
+  dispatch(movePlayer({ color, loc }));
+};
 
 interface PlayersState {
   players?: Player[];
@@ -11,6 +48,15 @@ const playersSlice = createSlice({
   name: 'players',
   initialState,
   reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(getPlayers.fulfilled, (state, { payload: players }) => {
+        state.players = players;
+      })
+      .addCase(movePlayer.fulfilled, (state, { payload: players }) => {
+        state.players = players;
+      });
+  },
 });
 
 export default playersSlice.reducer;

--- a/src/features/players.ts
+++ b/src/features/players.ts
@@ -1,0 +1,16 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { Player } from './models';
+
+interface PlayersState {
+  players?: Player[];
+}
+
+const initialState: PlayersState = {};
+
+const playersSlice = createSlice({
+  name: 'players',
+  initialState,
+  reducers: {},
+});
+
+export default playersSlice.reducer;

--- a/src/features/players.ts
+++ b/src/features/players.ts
@@ -6,9 +6,9 @@ import {
 } from '@reduxjs/toolkit';
 import { Player, PlayerColor } from './models';
 import * as api from '../api/api';
-import { GridLoc } from '../components/board/grid';
+import { equal, GridLoc } from '../components/board/grid';
 import { RootState } from '../rootReducer';
-import { getBoardMap } from './selectors';
+import { getBoardMap, getPlayers as selectPlayers } from './selectors';
 import { get } from '../board';
 
 export const getPlayers = createAsyncThunk('players/getStatus', api.getPlayers);
@@ -32,6 +32,13 @@ export const playerDropped: (
 ) => {
   const map = getBoardMap(getState())!!;
   if (!get(map, loc)) {
+    return;
+  }
+
+  const { loc: originalLoc } = selectPlayers(getState())!!.find(
+    (player) => player.color === color
+  )!!;
+  if (equal(originalLoc, loc)) {
     return;
   }
 

--- a/src/features/selectors.ts
+++ b/src/features/selectors.ts
@@ -4,11 +4,18 @@ import { RootState } from '../rootReducer';
 
 export const getRooms = (state: RootState) => state.board.rooms;
 
-export const getOpenNeighbors = createSelector([getRooms], (rooms) => {
+export const getBoardMap = createSelector([getRooms], (rooms) => {
   if (!rooms) {
     return;
   }
 
-  const map = buildBoardMap(rooms);
+  return buildBoardMap(rooms);
+});
+
+export const getOpenNeighbors = createSelector([getBoardMap], (map) => {
+  if (!map) {
+    return;
+  }
+
   return findOpenNeighbors(map);
 });

--- a/src/features/selectors.ts
+++ b/src/features/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { buildBoardMap, findOpenNeighbors } from '../board';
+import { buildMultiCartMap } from '../map';
 import { RootState } from '../rootReducer';
 
 export const getRooms = (state: RootState) => state.board.rooms;
@@ -18,4 +19,16 @@ export const getOpenNeighbors = createSelector([getBoardMap], (map) => {
   }
 
   return findOpenNeighbors(map);
+});
+
+export const getPlayers = (state: RootState) => state.players.players;
+
+export const getPlayerMap = createSelector([getPlayers], (players) => {
+  if (!players) {
+    return;
+  }
+
+  return buildMultiCartMap(players, ({ loc: { gridX: x, gridY: y } }) => {
+    return { x, y };
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,12 +8,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import { rootReducer } from './rootReducer';
 import { getRooms } from './features/board';
 import { getStackRoom } from './features/roomStack';
+import { getPlayers } from './features/players';
 
 const store = configureStore({
   reducer: rootReducer,
 });
 
 store.dispatch(getRooms());
+store.dispatch(getPlayers());
 store.dispatch(getStackRoom());
 
 ReactDOM.render(

--- a/src/map.ts
+++ b/src/map.ts
@@ -46,3 +46,12 @@ export const getPoint: <T>(map: CartMap<T>, p: Point) => T | undefined = (
 ) => {
   return getXY(map, x, y);
 };
+
+export const mapCartMap: <T, R>(
+  map: CartMap<T>,
+  mapper: (p: Point, t: T) => R
+) => R[] = <T, R>(map: CartMap<T>, mapper: (p: Point, t: T) => R) => {
+  return Array.from(map.entries()).flatMap(([x, column]) =>
+    Array.from(column.entries()).map(([y, t]) => mapper({ x, y }, t))
+  );
+};

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,0 +1,48 @@
+import { Point } from './components/geometry';
+
+type CartColumn<T> = Map<number, T>;
+export type CartMap<T> = Map<number, CartColumn<T>>;
+
+const set: <T>(map: CartMap<T>, p: Point, t: T) => CartMap<T> = <T>(
+  map: CartMap<T>,
+  { x, y }: Point,
+  t: T
+) => {
+  const column: CartColumn<T> = map.get(x) || new Map();
+  return map.set(x, column.set(y, t));
+};
+
+export const buildCartMap: <T>(
+  ts: T[],
+  getPoint: (t: T) => Point
+) => CartMap<T> = <T>(ts: T[], getPoint: (t: T) => Point) => {
+  return ts.reduce((map, t) => {
+    return set(map, getPoint(t), t);
+  }, new Map() as CartMap<T>);
+};
+
+export const buildMultiCartMap: <T>(
+  ts: T[],
+  getPoint: (t: T) => Point
+) => CartMap<T[]> = <T>(ts: T[], getPoint: (t: T) => Point) => {
+  return ts.reduce((map, t) => {
+    const { x, y } = getPoint(t);
+    const column: CartColumn<T[]> = map.get(x) || new Map();
+    return map.set(x, column.set(y, (column.get(y) || []).concat(t)));
+  }, new Map() as CartMap<T[]>);
+};
+
+export const getXY: <T>(
+  map: CartMap<T>,
+  x: number,
+  y: number
+) => T | undefined = (map, x, y) => {
+  return map.get(x)?.get(y);
+};
+
+export const getPoint: <T>(map: CartMap<T>, p: Point) => T | undefined = (
+  map,
+  { x, y }
+) => {
+  return getXY(map, x, y);
+};

--- a/src/rootReducer.ts
+++ b/src/rootReducer.ts
@@ -2,11 +2,13 @@ import { combineReducers } from '@reduxjs/toolkit';
 import zoomReducer from './features/zoom';
 import roomStackReducer from './features/roomStack';
 import boardReducer from './features/board';
+import playersReducer from './features/players';
 
 export const rootReducer = combineReducers({
   zoom: zoomReducer,
   roomStack: roomStackReducer,
   board: boardReducer,
+  players: playersReducer,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
Closes #5 

![move-players](https://user-images.githubusercontent.com/2991842/97443078-f077a780-1900-11eb-831c-1a56358db33d.gif)

There was some weird stuff to figure out for this feature.

Since the players were on the same draggable `Layer` as the rest of the board, dragging the player ended up also triggering a board move action which screwed with the board state. I found the `cancelBubble` event property which works like `preventDefault` on normal DOM events.

The player rows were re-rendering in a weird way when I moved a player in or out of the room. This was due to the list item optimizations in React; it doesn't re-render earlier list components if later ones have changed. However, since the layout of the players changes when any of them enter or leave, I needed to force a re-render for all of them. I used a random key for the player rows to achieve this.

Finally, I don't really know why but the drag event position for the players was already relative to the pan position of the board unlike when I implemented room placement. I still don't know why that is, but it made my job easier for this implementation; just had to pass the given position through. 