### PR TITLE
Fix drag-and-drop snap-back implementation

### DIFF
--- a/src/components/hooks.ts
+++ b/src/components/hooks.ts
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+
+export const useRender = () => {
+  const [value, setValue] = useState(0);
+  return () => {
+    setValue(value + 1);
+  };
+};

--- a/src/components/players/RoomPlayers.tsx
+++ b/src/components/players/RoomPlayers.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { Circle, Group } from 'react-konva';
 import { partition } from '../../utils';
 import { translate } from '../geometry';
@@ -12,18 +12,19 @@ import { Player as PlayerModel, PlayerColor } from '../../features/models';
 import { useDispatch } from 'react-redux';
 import { playerDropped } from '../../features/players';
 import { BoundingBox, getCenter, getPlayersBox } from '../layout';
+import { useRender } from '../hooks';
 
-export interface PlayerProps {
+interface PlayerProps {
   color: PlayerColor;
   box: BoundingBox;
 }
 
 const Player: FunctionComponent<PlayerProps> = ({ box, color }) => {
-  const originalCenter = getCenter(box);
+  const { x, y } = getCenter(box);
   const { width, height } = box.dimensions;
   const radius = Math.min(width, height) / 2;
 
-  const [{ x, y }, setCenter] = useState(originalCenter);
+  const render = useRender();
   const dispatch = useDispatch();
   const gridSize = useGridSize();
 
@@ -42,8 +43,7 @@ const Player: FunctionComponent<PlayerProps> = ({ box, color }) => {
           playerDropped(color, pointToGridLoc(e.target.position(), gridSize))
         );
 
-        setCenter({ x: e.target.x(), y: e.target.y() });
-        setCenter(originalCenter);
+        render(); // to snap back if dropped in an invalid spot
       }}
     />
   );
@@ -113,7 +113,7 @@ const RoomPlayers: FunctionComponent<RoomPlayersProps> = ({
     <Group>
       {byRow.map((row, i) => (
         <PlayersRow
-          key={Math.random()}
+          key={i}
           box={{
             topLeft: translate(topLeft, 0, i * rowHeight),
             dimensions: { width, height: rowHeight },

--- a/src/components/roomStack/FlippedStackRoom.tsx
+++ b/src/components/roomStack/FlippedStackRoom.tsx
@@ -1,11 +1,12 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent } from 'react';
 import { Group } from 'react-konva';
 import { useDispatch, useSelector } from 'react-redux';
 import { flippedRoomDropped } from '../../features/board';
 import { Feature } from '../../features/models';
 import { RootState } from '../../rootReducer';
 import { useGridSize, windowToGridLoc } from '../board/grid';
-import { Point, translate } from '../geometry';
+import { translate } from '../geometry';
+import { useRender } from '../hooks';
 import { BoundingBox, getDoorDimensions } from '../layout';
 import Room, { Direction } from '../room/Room';
 import RoomFeatures from '../room/RoomFeatures';
@@ -45,10 +46,12 @@ const FlippedStackRoom: FunctionComponent<FlippedStackRoomProps> = ({
   const dispatch = useDispatch();
   const gridSize = useGridSize();
   const boardTopLeft = useSelector((state: RootState) => state.board.topLeft);
-  const [groupTopLeft, setGroupTopLeft] = useState<Point>({ x: 0, y: 0 });
+  const render = useRender();
 
   return (
     <Group
+      x={0}
+      y={0}
       draggable
       onDragEnd={(e) => {
         const { x, y } = e.target.position();
@@ -63,11 +66,9 @@ const FlippedStackRoom: FunctionComponent<FlippedStackRoomProps> = ({
           boardTopLeft
         );
         dispatch(flippedRoomDropped(gridDroppedOn));
-        setGroupTopLeft({ x, y });
-        setGroupTopLeft({ x: 0, y: 0 });
+
+        render();
       }}
-      x={groupTopLeft.x}
-      y={groupTopLeft.y}
     >
       <Room box={roomBox} doorDirections={doorDirections} />
       <RoomName box={nameBox} name={name} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,9 @@ import { rootReducer } from './rootReducer';
 import { getRooms } from './features/board';
 import { getStackRoom } from './features/roomStack';
 import { getPlayers } from './features/players';
+import { useStrictMode } from 'react-konva';
+
+useStrictMode(true);
 
 const store = configureStore({
   reducer: rootReducer,


### PR DESCRIPTION
Both players and the room to be placed can be dragged to move them. If these elements are dropped in locations they can't be moved to (like outside of any room in the case of players), they'll snap back to their original location. I implemented this by using the player's center coordinates (passed as a prop) in a call to the `setState` so I could set it back to its original position.

However, while implementing the player movement, I had to work around what I thought at the time was a quirk of the interaction between React and Konva, the canvas library I'm using which has React bindings. Basically, the players wouldn't be laid out correctly with the new player in place.

![incorrect player layout](https://user-images.githubusercontent.com/2991842/99005011-03e45e80-250e-11eb-86b6-f9078b22a6b7.gif)

I thought this was because React wasn't correctly identifying what elements needed to be updated. My work-around was to use a random `key` for the player row element. That basically told React to tear down and rebuild all the players on every render, so they always ended up rendered correctly.

Today, I felt compelled to figure out what was going on here while working on a different feature around player interactions. After _a lot_ of debugging through the React reconciliation configuration implemented by Konva, I realized the problem was my snap-back work-around. My use of a prop directly in `setState`  meant the `Player` component was ignoring new bounding box values that were being passed in. [This React blog post][1] lays out the problem with this approach in good detail.

My solution here is to use Konva's strict mode (meaning it will automatically snap dragged elements back to where they were on the next render) and to use a little hook I wrote that alters some useless state to get React to rerender the element to snap back. This means the passed-in bounding box prop is always respected and never overriden by internal state.

This took a lot of time and I'm sure there's a more elegant way to do the rerender rather than some pointless state, but it works well, leads to more efficient rendering of all the players, and feels overall less janky to me than the previous solution.

[1]: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#common-bugs-when-using-derived-state