### PR TITLE
Add preview for room placement

### DIFF
--- a/src/components/game/board/OpenSpot.tsx
+++ b/src/components/game/board/OpenSpot.tsx
@@ -1,8 +1,9 @@
-import React, { FunctionComponent } from 'react';
-import { Rect } from 'react-konva';
-import { useDispatch } from 'react-redux';
+import React, { FunctionComponent, useState } from 'react';
+import { Group, Rect } from 'react-konva';
+import { useDispatch, useSelector } from 'react-redux';
 import { openSpotClicked } from '../../../features/board';
-import { Direction } from '../room/Room';
+import { RootState } from '../../../store';
+import Room, { Direction } from '../room/Room';
 import { GridLoc, useGridBox } from './grid';
 
 interface OpenSpotProps {
@@ -11,13 +12,36 @@ interface OpenSpotProps {
 }
 
 const OpenSpot: FunctionComponent<OpenSpotProps> = ({ loc, from }) => {
+  const box = useGridBox(loc);
   const {
     topLeft: { x, y },
     dimensions: { width, height },
-  } = useGridBox(loc);
-
+  } = box;
+  const [hovered, setHovered] = useState(false);
   const dispatch = useDispatch();
   const onClick = () => dispatch(openSpotClicked(loc, from));
+  const flippedRoom = useSelector(
+    (state: RootState) => state.roomStack.flippedRoom
+  );
+  const onMouseEnter = () => setHovered(true);
+  const onMouseLeave = () => setHovered(false);
+
+  if (hovered && flippedRoom) {
+    return (
+      <Group
+        onClick={onClick}
+        onTap={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        <Room
+          box={box}
+          doorDirections={flippedRoom.doorDirections}
+          opacity={0.7}
+        />
+      </Group>
+    );
+  }
 
   return (
     <Rect
@@ -27,6 +51,8 @@ const OpenSpot: FunctionComponent<OpenSpotProps> = ({ loc, from }) => {
       height={height}
       onClick={onClick}
       onTap={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     />
   );
 };

--- a/src/components/game/room/Room.tsx
+++ b/src/components/game/room/Room.tsx
@@ -78,9 +78,14 @@ const Door: FunctionComponent<DoorProps> = ({ roomBox, direction }) => {
 interface RoomProps {
   box: BoundingBox;
   doorDirections: Direction[];
+  opacity?: number;
 }
 
-const Room: FunctionComponent<RoomProps> = ({ box, doorDirections }) => {
+const Room: FunctionComponent<RoomProps> = ({
+  box,
+  doorDirections,
+  opacity,
+}) => {
   const {
     topLeft: { x, y },
     dimensions: { width, height },
@@ -91,7 +96,7 @@ const Room: FunctionComponent<RoomProps> = ({ box, doorDirections }) => {
   });
 
   return (
-    <Group>
+    <Group opacity={opacity || 1}>
       <Rect x={x} y={y} width={width} height={height} fill="black" />
       {doors}
       <Rect x={x} y={y} width={width} height={height} stroke="teal" />


### PR DESCRIPTION
Since I had to remove the drag-and-drop room placement in #48, these previews should improve the click-to-place experience.

https://user-images.githubusercontent.com/2991842/117982975-88206e80-b304-11eb-9de4-37761e413e57.mov

