### PR TITLE
Switch to React Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-redux": "^7.1.9",
+    "@types/react-router": "^5.1.18",
+    "@types/react-router-dom": "^5.3.3",
     "prettier": "2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "react-dom": "^16.14.0",
     "react-konva": "^16.13.0-6",
     "react-redux": "^7.2.1",
+    "react-router": "^6.3.0",
+    "react-router-dom": "^6.3.0",
     "react-scripts": "^4.0.0",
     "redux": "^4.0.5",
     "typescript": "^4"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,14 +1,13 @@
-import { Router } from '@reach/router';
-import React from 'react';
+import { Route, Routes } from 'react-router';
 import Game from './game/Game';
 import Home from './Home';
 
 const App = () => {
   return (
-    <Router>
-      <Home path="/" />
-      <Game path="/game/:gameId" />
-    </Router>
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/game/:gameId" element={<Game />} />
+    </Routes>
   );
 };
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -3,9 +3,7 @@ import React, { FC, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createGame } from '../api/api';
 
-interface HomeProps {}
-
-const Home: FC<HomeProps> = () => {
+const Home: FC<{}> = () => {
   const navigate = useNavigate();
   const [gameId, setGameId] = useState('');
   const numPlayersRef = useRef<HTMLInputElement>(null);

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,9 +1,9 @@
 import './Home.css';
 import React, { FC, useRef, useState } from 'react';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { useNavigate } from 'react-router-dom';
 import { createGame } from '../api/api';
 
-interface HomeProps extends RouteComponentProps {}
+interface HomeProps {}
 
 const Home: FC<HomeProps> = () => {
   const navigate = useNavigate();

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -7,7 +7,7 @@ import { getRooms, moveBoard } from '../../features/board';
 import { RootState } from '../../store';
 import Agents from './players/Agents';
 import Sidebar from './sidebar/Sidebar';
-import { RouteComponentProps, useNavigate } from '@reach/router';
+import { RouteComponentProps, useNavigate, useParams } from '@reach/router';
 import { joinGame } from '../../features/game';
 import { getPlayers } from '../../features/players';
 import { getRoomStack } from '../../features/roomStack';
@@ -25,11 +25,10 @@ const buildWebsocketUrl = (gameId: string) => {
   return `${wsRoot}/games/${gameId}`;
 };
 
-interface GameProps extends RouteComponentProps {
-  gameId?: string;
-}
+interface GameProps extends RouteComponentProps {}
 
-const Game: FC<GameProps> = ({ gameId }) => {
+const Game: FC<GameProps> = () => {
+  const { gameId } = useParams();
   const { width, height } = useWindowDimensions();
   const dispatch = useDispatch();
   const navigate = useNavigate();

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -25,9 +25,7 @@ const buildWebsocketUrl = (gameId: string) => {
   return `${wsRoot}/games/${gameId}`;
 };
 
-interface GameProps {}
-
-const Game: FC<GameProps> = () => {
+const Game: FC<{}> = () => {
   const { gameId } = useParams();
   const { width, height } = useWindowDimensions();
   const dispatch = useDispatch();

--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -7,7 +7,7 @@ import { getRooms, moveBoard } from '../../features/board';
 import { RootState } from '../../store';
 import Agents from './players/Agents';
 import Sidebar from './sidebar/Sidebar';
-import { RouteComponentProps, useNavigate, useParams } from '@reach/router';
+import { useNavigate, useParams } from 'react-router-dom';
 import { joinGame } from '../../features/game';
 import { getPlayers } from '../../features/players';
 import { getRoomStack } from '../../features/roomStack';
@@ -25,7 +25,7 @@ const buildWebsocketUrl = (gameId: string) => {
   return `${wsRoot}/games/${gameId}`;
 };
 
-interface GameProps extends RouteComponentProps {}
+interface GameProps {}
 
 const Game: FC<GameProps> = () => {
   const { gameId } = useParams();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import App from './components/App';
 import * as serviceWorker from './serviceWorker';
 import { useStrictMode } from 'react-konva';
 import { store } from './store';
-import { LocationProvider } from '@reach/router';
+import { BrowserRouter } from 'react-router-dom';
 
 // ESLint thinks this is a React hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -14,11 +14,11 @@ useStrictMode(true);
 
 ReactDOM.render(
   <React.StrictMode>
-    <LocationProvider>
+    <BrowserRouter>
       <Provider store={store}>
         <App />
       </Provider>
-    </LocationProvider>
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import App from './components/App';
 import * as serviceWorker from './serviceWorker';
 import { useStrictMode } from 'react-konva';
 import { store } from './store';
+import { LocationProvider } from '@reach/router';
 
 // ESLint thinks this is a React hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -13,9 +14,11 @@ useStrictMode(true);
 
 ReactDOM.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
+    <LocationProvider>
+      <Provider store={store}>
+        <App />
+      </Provider>
+    </LocationProvider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,7 +1035,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
   integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
@@ -5591,6 +5591,13 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9300,6 +9307,21 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-router-dom@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.3.0"
+
+react-router@6.3.0, react-router@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@^4.0.0:
   version "4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -1888,6 +1893,23 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
+
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*", "@types/react-router@^5.1.18":
+  version "5.1.18"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.18.tgz#c8851884b60bc23733500d86c1266e1cfbbd9ef3"
+  integrity sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
 
 "@types/react@*":
   version "18.0.6"


### PR DESCRIPTION
Closes #64 

Mostly followed [the official migration guide](https://reactrouterdotcom.fly.dev/docs/en/v6/upgrading/reach), but had some trouble in a couple of places. For example, the guide doesn't explicitly call out the need to changes imports, so I was getting weird error messages about using `useNavigate` from outside of a router (which were actually from Reach and not React Router).